### PR TITLE
Add simple video sync via BroadcastChannel

### DIFF
--- a/components/video-viewer.tsx
+++ b/components/video-viewer.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Square, Wifi, WifiOff } from "lucide-react"
+import { Square, Wifi, WifiOff, Play, Pause, Volume2 } from "lucide-react"
 import FloatingVideoCall from "@/components/floating-video-call"
+import useVideoSync from "@/hooks/use-video-sync"
 
 interface VideoViewerProps {
   onStop: () => void
@@ -14,52 +15,101 @@ interface VideoViewerProps {
 
 export default function VideoViewer({ onStop, isInCall = false, isUserA = false }: VideoViewerProps) {
   const [isConnected, setIsConnected] = useState(false)
-  const [isBuffering, setIsBuffering] = useState(true)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const { broadcast, remoteVideoUrl } = useVideoSync(videoRef)
 
   useEffect(() => {
-    // Simulate connection and buffering
-    const connectTimer = setTimeout(() => {
+    if (remoteVideoUrl) {
       setIsConnected(true)
-      setIsBuffering(false)
-    }, 2000)
+    }
+  }, [remoteVideoUrl])
 
-    return () => clearTimeout(connectTimer)
-  }, [])
+  const togglePlay = () => {
+    if (videoRef.current) {
+      if (isPlaying) {
+        videoRef.current.pause()
+        broadcast({ type: "pause", currentTime: videoRef.current.currentTime })
+      } else {
+        videoRef.current.play()
+        broadcast({ type: "play", currentTime: videoRef.current.currentTime })
+      }
+      setIsPlaying(!isPlaying)
+    }
+  }
+
+  const handleTimeUpdate = () => {
+    if (videoRef.current) {
+      setCurrentTime(videoRef.current.currentTime)
+    }
+  }
+
+  const handleLoadedMetadata = () => {
+    if (videoRef.current) {
+      setDuration(videoRef.current.duration)
+    }
+  }
+
+  const handleSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const time = Number.parseFloat(e.target.value)
+    if (videoRef.current) {
+      videoRef.current.currentTime = time
+      setCurrentTime(time)
+      broadcast({ type: "seek", currentTime: time })
+    }
+  }
+
+  const formatTime = (time: number) => {
+    const minutes = Math.floor(time / 60)
+    const seconds = Math.floor(time % 60)
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`
+  }
 
   return (
     <div className="space-y-4">
       <Card>
         <CardContent className="p-0">
-          <div className="relative bg-black rounded-lg overflow-hidden aspect-video">
-            {isBuffering ? (
+          <div className="relative bg-black rounded-lg overflow-hidden">
+            {!remoteVideoUrl ? (
               <div className="absolute inset-0 flex items-center justify-center">
                 <div className="text-center text-white">
                   <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-white mx-auto mb-4"></div>
-                  <p>Connecting to stream...</p>
+                  <p>Waiting for stream...</p>
                 </div>
               </div>
             ) : (
               <>
-                {/* Simulated video stream */}
-                <div className="w-full h-full bg-gradient-to-br from-blue-900 to-purple-900 flex items-center justify-center">
-                  <div className="text-center text-white">
-                    <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
-                      <div className="w-8 h-8 bg-red-500 rounded-full animate-pulse"></div>
-                    </div>
-                    <p className="text-lg font-medium">Live Stream Active</p>
-                    <p className="text-sm opacity-75">Receiving HD video from User A</p>
-                  </div>
-                </div>
+                <video
+                  ref={videoRef}
+                  src={remoteVideoUrl}
+                  className="w-full h-auto max-h-96"
+                  onTimeUpdate={handleTimeUpdate}
+                  onLoadedMetadata={handleLoadedMetadata}
+                  onEnded={() => setIsPlaying(false)}
+                />
 
-                {/* Stream info overlay */}
-                <div className="absolute top-4 left-4 bg-black/50 rounded-lg px-3 py-2 text-white text-sm">
-                  <div className="flex items-center gap-2">
-                    {isConnected ? (
-                      <Wifi className="w-4 h-4 text-green-400" />
-                    ) : (
-                      <WifiOff className="w-4 h-4 text-red-400" />
-                    )}
-                    <span>HD • Live</span>
+                <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-4">
+                  <div className="flex items-center gap-4 text-white">
+                    <Button size="sm" variant="ghost" onClick={togglePlay} className="text-white hover:bg-white/20">
+                      {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+                    </Button>
+
+                    <div className="flex-1 flex items-center gap-2">
+                      <span className="text-sm">{formatTime(currentTime)}</span>
+                      <input
+                        type="range"
+                        min="0"
+                        max={duration || 0}
+                        value={currentTime}
+                        onChange={handleSeek}
+                        className="flex-1 h-1 bg-white/30 rounded-lg appearance-none cursor-pointer"
+                      />
+                      <span className="text-sm">{formatTime(duration)}</span>
+                    </div>
+
+                    <Volume2 className="w-4 h-4" />
                   </div>
                 </div>
               </>
@@ -71,15 +121,13 @@ export default function VideoViewer({ onStop, isInCall = false, isUserA = false 
       {isInCall && (
         <FloatingVideoCall
           isUserA={isUserA}
-          onEndCall={() => {}} // This will be handled by parent component
+          onEndCall={() => {}}
         />
       )}
 
       <div className="flex items-center justify-between">
         <div className="text-sm text-gray-600">
-          <p className="font-medium">
-            Status: {isBuffering ? "Connecting..." : isConnected ? "Connected" : "Disconnected"}
-          </p>
+          <p className="font-medium">Status: {isConnected ? "Connected" : "Waiting"}</p>
           <p>Quality: HD • Latency: Low</p>
         </div>
         <Button onClick={onStop} variant="destructive" className="flex items-center gap-2">

--- a/hooks/use-video-sync.tsx
+++ b/hooks/use-video-sync.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from "react"
+
+export interface VideoSyncMessage {
+  type: "file" | "play" | "pause" | "seek"
+  dataUrl?: string
+  currentTime?: number
+  sender?: string
+}
+
+export default function useVideoSync(videoRef: React.RefObject<HTMLVideoElement>) {
+  const [remoteVideoUrl, setRemoteVideoUrl] = useState<string>("")
+  const channelRef = useRef<BroadcastChannel | null>(null)
+  const idRef = useRef<string>("" + Math.random())
+
+  useEffect(() => {
+    const channel = new BroadcastChannel("video-sync")
+    channelRef.current = channel
+
+    channel.onmessage = (event: MessageEvent<VideoSyncMessage>) => {
+      const msg = event.data
+      if (msg.sender === idRef.current) return
+      const video = videoRef.current
+      if (!video) return
+      switch (msg.type) {
+        case "file":
+          if (msg.dataUrl) setRemoteVideoUrl(msg.dataUrl)
+          break
+        case "play":
+          if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
+          video.play().catch(() => {})
+          break
+        case "pause":
+          if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
+          video.pause()
+          break
+        case "seek":
+          if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
+          break
+      }
+    }
+
+    return () => channel.close()
+  }, [videoRef])
+
+  const broadcast = (msg: Omit<VideoSyncMessage, "sender">) => {
+    channelRef.current?.postMessage({ ...msg, sender: idRef.current })
+  }
+
+  return { broadcast, remoteVideoUrl, setRemoteVideoUrl }
+}


### PR DESCRIPTION
## Summary
- create `useVideoSync` hook that synchronises video actions using the `BroadcastChannel` API
- broadcast video file and playback events from `VideoStreamer`
- make `VideoViewer` show and control the synced video instead of a static placeholder

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856d6a375b0832f8cc8669b12fb1f82