### PR TITLE
Add room ID sharing, fix video src

### DIFF
--- a/components/user-a-page.tsx
+++ b/components/user-a-page.tsx
@@ -16,6 +16,7 @@ export default function UserAPage({ onBack }: UserAPageProps) {
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const [isStreaming, setIsStreaming] = useState(false)
   const [isInCall, setIsInCall] = useState(false)
+  const [roomId, setRoomId] = useState("")
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -32,7 +33,12 @@ export default function UserAPage({ onBack }: UserAPageProps) {
   }
 
   const toggleCall = () => {
-    setIsInCall(!isInCall)
+    if (!isInCall) {
+      setRoomId(crypto.randomUUID())
+      setIsInCall(true)
+    } else {
+      setIsInCall(false)
+    }
   }
 
   return (
@@ -97,6 +103,8 @@ export default function UserAPage({ onBack }: UserAPageProps) {
                     onStop={() => setIsStreaming(false)}
                     isInCall={isInCall}
                     isUserA={true}
+                    roomId={roomId}
+                    onEndCall={() => setIsInCall(false)}
                   />
                 )}
               </CardContent>
@@ -127,6 +135,11 @@ export default function UserAPage({ onBack }: UserAPageProps) {
                       ? "Video call is active. User B's video appears in the streaming window."
                       : "Start a call to see User B's video overlay."}
                   </p>
+                  {isInCall && (
+                    <p className="text-sm text-gray-800 break-all">
+                      Room ID: <span className="font-mono">{roomId}</span>
+                    </p>
+                  )}
                 </div>
                 <div className="text-sm text-gray-500 space-y-2">
                   <p>• Your video is sent to User B</p>

--- a/components/user-b-page.tsx
+++ b/components/user-b-page.tsx
@@ -13,13 +13,18 @@ interface UserBPageProps {
 export default function UserBPage({ onBack }: UserBPageProps) {
   const [isWatching, setIsWatching] = useState(false)
   const [isInCall, setIsInCall] = useState(false)
+  const [roomId, setRoomId] = useState("")
 
   const startWatching = () => {
     setIsWatching(true)
   }
 
   const toggleCall = () => {
-    setIsInCall(!isInCall)
+    if (isInCall) {
+      setIsInCall(false)
+    } else if (roomId.trim()) {
+      setIsInCall(true)
+    }
   }
 
   return (
@@ -31,7 +36,14 @@ export default function UserBPage({ onBack }: UserBPageProps) {
             Back
           </Button>
           <h1 className="text-3xl font-bold text-gray-900">User B Dashboard</h1>
-          <div className="ml-auto">
+          <div className="ml-auto flex items-center gap-2">
+            <input
+              type="text"
+              value={roomId}
+              onChange={(e) => setRoomId(e.target.value)}
+              placeholder="Room ID"
+              className="px-2 py-1 text-sm border border-gray-300 rounded"
+            />
             <Button
               onClick={toggleCall}
               variant={isInCall ? "destructive" : "default"}
@@ -63,7 +75,13 @@ export default function UserBPage({ onBack }: UserBPageProps) {
                     </Button>
                   </div>
                 ) : (
-                  <VideoViewer onStop={() => setIsWatching(false)} isInCall={isInCall} isUserA={false} />
+                  <VideoViewer
+                    onStop={() => setIsWatching(false)}
+                    isInCall={isInCall}
+                    isUserA={false}
+                    roomId={roomId}
+                    onEndCall={() => setIsInCall(false)}
+                  />
                 )}
               </CardContent>
             </Card>
@@ -93,6 +111,11 @@ export default function UserBPage({ onBack }: UserBPageProps) {
                       ? "Video call is active. User A's video appears in the streaming window."
                       : "Join a call to see User A's video overlay."}
                   </p>
+                  {isInCall && (
+                    <p className="text-sm text-gray-800 break-all">
+                      Room ID: <span className="font-mono">{roomId}</span>
+                    </p>
+                  )}
                 </div>
                 <div className="text-sm text-gray-500 space-y-2">
                   <p>• Your video is sent to User A</p>

--- a/components/video-streamer.tsx
+++ b/components/video-streamer.tsx
@@ -14,9 +14,18 @@ interface VideoStreamerProps {
   onStop: () => void
   isInCall?: boolean
   isUserA?: boolean
+  roomId?: string
+  onEndCall?: () => void
 }
 
-export default function VideoStreamer({ file, onStop, isInCall = false, isUserA = true }: VideoStreamerProps) {
+export default function VideoStreamer({
+  file,
+  onStop,
+  isInCall = false,
+  isUserA = true,
+  roomId = "main-room",
+  onEndCall,
+}: VideoStreamerProps) {
   const [isPlaying, setIsPlaying] = useState(false)
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
@@ -83,14 +92,18 @@ export default function VideoStreamer({ file, onStop, isInCall = false, isUserA 
       <Card>
         <CardContent className="p-0">
           <div className="relative bg-black rounded-lg overflow-hidden">
-            <video
-              ref={videoRef}
-              src={videoUrl}
-              className="w-full h-auto max-h-96"
-              onTimeUpdate={handleTimeUpdate}
-              onLoadedMetadata={handleLoadedMetadata}
-              onEnded={() => setIsPlaying(false)}
-            />
+            {videoUrl ? (
+              <video
+                ref={videoRef}
+                src={videoUrl}
+                className="w-full h-auto max-h-96"
+                onTimeUpdate={handleTimeUpdate}
+                onLoadedMetadata={handleLoadedMetadata}
+                onEnded={() => setIsPlaying(false)}
+              />
+            ) : (
+              <div className="w-full h-auto max-h-96 bg-black" />
+            )}
 
             {/* Video Controls Overlay */}
             <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-4">
@@ -122,8 +135,8 @@ export default function VideoStreamer({ file, onStop, isInCall = false, isUserA 
       {isInCall && (
         <FloatingVideoCall
           isUserA={isUserA}
-          roomId="main-room"
-          onEndCall={() => {}}
+          roomId={roomId}
+          onEndCall={onEndCall}
         />
       )}
 

--- a/components/video-viewer.tsx
+++ b/components/video-viewer.tsx
@@ -11,9 +11,17 @@ interface VideoViewerProps {
   onStop: () => void
   isInCall?: boolean
   isUserA?: boolean
+  roomId?: string
+  onEndCall?: () => void
 }
 
-export default function VideoViewer({ onStop, isInCall = false, isUserA = false }: VideoViewerProps) {
+export default function VideoViewer({
+  onStop,
+  isInCall = false,
+  isUserA = false,
+  roomId = "main-room",
+  onEndCall,
+}: VideoViewerProps) {
   const [isConnected, setIsConnected] = useState(false)
   const [isPlaying, setIsPlaying] = useState(false)
   const [currentTime, setCurrentTime] = useState(0)
@@ -121,8 +129,8 @@ export default function VideoViewer({ onStop, isInCall = false, isUserA = false 
       {isInCall && (
         <FloatingVideoCall
           isUserA={isUserA}
-          roomId="main-room"
-          onEndCall={() => {}}
+          roomId={roomId}
+          onEndCall={onEndCall}
         />
       )}
 


### PR DESCRIPTION
## Summary
- let User A generate a room ID and display it during a call
- allow User B to input a room ID before joining
- pass roomId to video call components
- show roomId in call status panels
- avoid empty `src` attribute in `VideoStreamer`

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6856e30d4000832fa43ae7539ccca1ce