### PR TITLE
Fix empty src warnings

### DIFF
--- a/components/video-streamer.tsx
+++ b/components/video-streamer.tsx
@@ -29,7 +29,7 @@ export default function VideoStreamer({
   const [isPlaying, setIsPlaying] = useState(false)
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
-  const [videoUrl, setVideoUrl] = useState<string>("")
+  const [videoUrl, setVideoUrl] = useState<string | null>(null)
   const videoRef = useRef<HTMLVideoElement>(null)
   const { broadcast } = useVideoSync(videoRef)
 
@@ -92,10 +92,10 @@ export default function VideoStreamer({
       <Card>
         <CardContent className="p-0">
           <div className="relative bg-black rounded-lg overflow-hidden">
-            {videoUrl ? (
-              <video
-                ref={videoRef}
-                src={videoUrl}
+              {videoUrl ? (
+                <video
+                  ref={videoRef}
+                  src={videoUrl || undefined}
                 className="w-full h-auto max-h-96"
                 onTimeUpdate={handleTimeUpdate}
                 onLoadedMetadata={handleLoadedMetadata}

--- a/components/video-viewer.tsx
+++ b/components/video-viewer.tsx
@@ -91,7 +91,7 @@ export default function VideoViewer({
               <>
                 <video
                   ref={videoRef}
-                  src={remoteVideoUrl}
+                  src={remoteVideoUrl || undefined}
                   className="w-full h-auto max-h-96"
                   onTimeUpdate={handleTimeUpdate}
                   onLoadedMetadata={handleLoadedMetadata}

--- a/hooks/use-video-sync.tsx
+++ b/hooks/use-video-sync.tsx
@@ -7,7 +7,7 @@ export interface VideoSyncMessage {
   sender?: string
 }
 export default function useVideoSync(videoRef: React.RefObject<HTMLVideoElement>) {
-  const [remoteVideoUrl, setRemoteVideoUrl] = useState<string>("")
+  const [remoteVideoUrl, setRemoteVideoUrl] = useState<string | null>(null)
   const channelRef = useRef<BroadcastChannel | null>(null)
   const idRef = useRef<string>("" + Math.random())
 


### PR DESCRIPTION
## Summary
- avoid passing empty strings to `<video>` elements
- support optional remote video URLs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856e5477ec8832fbafb5c283f9671d7