### PR TITLE
Gracefully handle missing media devices

### DIFF
--- a/hooks/use-web-rtc.tsx
+++ b/hooks/use-web-rtc.tsx
@@ -70,7 +70,20 @@ export default function useWebRTC({ roomId, isInitiator }: UseWebRTCOptions) {
 
     const start = async () => {
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true })
+        const devices = await navigator.mediaDevices.enumerateDevices()
+        const hasVideo = devices.some((d) => d.kind === "videoinput")
+        const hasAudio = devices.some((d) => d.kind === "audioinput")
+
+        const constraints: MediaStreamConstraints = {}
+        if (hasVideo) constraints.video = true
+        if (hasAudio) constraints.audio = true
+
+        if (!hasVideo && !hasAudio) {
+          console.warn("No media devices available")
+          return
+        }
+
+        const stream = await navigator.mediaDevices.getUserMedia(constraints)
         localStreamRef.current = stream
         setLocalStream(stream)
         stream.getTracks().forEach((track) => peer.addTrack(track, stream))


### PR DESCRIPTION
## Summary
- handle missing media device scenario in `useWebRTC`
- warn if no webcam or microphone

## Testing
- `npm run build`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6856ea35ec80832fb65d88b814051af8