### PR TITLE
Fix video sync when viewer joins late

### DIFF
--- a/hooks/use-video-sync.tsx
+++ b/hooks/use-video-sync.tsx
@@ -18,21 +18,25 @@ export default function useVideoSync(videoRef: React.RefObject<HTMLVideoElement>
     channel.onmessage = (event: MessageEvent<VideoSyncMessage>) => {
       const msg = event.data
       if (msg.sender === idRef.current) return
+
       const video = videoRef.current
-      if (!video) return
+
       switch (msg.type) {
         case "file":
           if (msg.dataUrl) setRemoteVideoUrl(msg.dataUrl)
           break
         case "play":
+          if (!video) return
           if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
           video.play().catch(() => {})
           break
         case "pause":
+          if (!video) return
           if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
           video.pause()
           break
         case "seek":
+          if (!video) return
           if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
           break
       }


### PR DESCRIPTION
## Summary
- handle file messages even if video element isn't available yet

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856edecc9e0832fa72f7db30fee465c