### PR TITLE
Fix video sync when viewer joins late

### DIFF
--- a/app/api/signaling/route.ts
+++ b/app/api/signaling/route.ts
@@ -1,0 +1,28 @@
+interface StoredMessage {
+  id: number
+  data: any
+}
+
+const channels: Record<string, StoredMessage[]> = (globalThis as any).channels || {}
+;(globalThis as any).channels = channels
+
+export async function POST(req: Request) {
+  const { roomId, message } = await req.json()
+  if (!roomId) {
+    return new Response("roomId required", { status: 400 })
+  }
+  if (!channels[roomId]) channels[roomId] = []
+  const msg = { id: Date.now() + Math.random(), data: message }
+  channels[roomId].push(msg)
+  return Response.json({ id: msg.id })
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const roomId = searchParams.get("roomId")
+  const after = parseFloat(searchParams.get("after") || "0")
+  if (!roomId) return new Response("roomId required", { status: 400 })
+  const msgs = channels[roomId] || []
+  const resMsgs = msgs.filter((m) => m.id > after)
+  return Response.json({ messages: resMsgs })
+}

--- a/hooks/use-network-channel.ts
+++ b/hooks/use-network-channel.ts
@@ -1,0 +1,56 @@
+"use client"
+import { useEffect, useRef } from "react"
+
+export interface ChannelMessage {
+  id: number
+  data: any
+}
+
+export default function useNetworkChannel(
+  roomId: string,
+  onMessage: (msg: any) => void,
+) {
+  const lastIdRef = useRef(0)
+  const stopRef = useRef(false)
+
+  useEffect(() => {
+    stopRef.current = false
+    const poll = async () => {
+      while (!stopRef.current) {
+        try {
+          const res = await fetch(
+            `/api/signaling?roomId=${encodeURIComponent(roomId)}&after=${lastIdRef.current}`,
+          )
+          if (res.ok) {
+            const { messages } = await res.json()
+            for (const m of messages as ChannelMessage[]) {
+              lastIdRef.current = Math.max(lastIdRef.current, m.id)
+              onMessage(m.data)
+            }
+          }
+        } catch (err) {
+          console.error(err)
+        }
+        await new Promise((r) => setTimeout(r, 500))
+      }
+    }
+    poll()
+    return () => {
+      stopRef.current = true
+    }
+  }, [roomId, onMessage])
+
+  const sendMessage = async (data: any) => {
+    try {
+      await fetch("/api/signaling", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ roomId, message: data }),
+      })
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return { sendMessage }
+}

--- a/hooks/use-video-sync.tsx
+++ b/hooks/use-video-sync.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import useNetworkChannel from "./use-network-channel"
 
 export interface VideoSyncMessage {
   type: "file" | "play" | "pause" | "seek"
@@ -8,41 +9,35 @@ export interface VideoSyncMessage {
 }
 export default function useVideoSync(videoRef: React.RefObject<HTMLVideoElement>) {
   const [remoteVideoUrl, setRemoteVideoUrl] = useState<string | null>(null)
-  const channelRef = useRef<BroadcastChannel | null>(null)
   const idRef = useRef<string>("" + Math.random())
 
-  useEffect(() => {
-    const channel = new BroadcastChannel("video-sync")
-    channelRef.current = channel
+  const { sendMessage } = useNetworkChannel("video-sync", (msg: VideoSyncMessage) => {
+    if (msg.sender === idRef.current) return
 
-    channel.onmessage = (event: MessageEvent<VideoSyncMessage>) => {
-      const msg = event.data
-      if (msg.sender === idRef.current) return
-      const video = videoRef.current
-      if (!video) return
-      switch (msg.type) {
-        case "file":
-          if (msg.dataUrl) setRemoteVideoUrl(msg.dataUrl)
-          break
-        case "play":
-          if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
-          video.play().catch(() => {})
-          break
-        case "pause":
-          if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
-          video.pause()
-          break
-        case "seek":
-          if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
-          break
-      }
+    const video = videoRef.current
+    switch (msg.type) {
+      case "file":
+        if (msg.dataUrl) setRemoteVideoUrl(msg.dataUrl)
+        break
+      case "play":
+        if (!video) return
+        if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
+        video.play().catch(() => {})
+        break
+      case "pause":
+        if (!video) return
+        if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
+        video.pause()
+        break
+      case "seek":
+        if (!video) return
+        if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
+        break
     }
-
-    return () => channel.close()
-  }, [videoRef])
+  })
 
   const broadcast = (msg: Omit<VideoSyncMessage, "sender">) => {
-    channelRef.current?.postMessage({ ...msg, sender: idRef.current })
+    sendMessage({ ...msg, sender: idRef.current })
   }
 
   return { broadcast, remoteVideoUrl, setRemoteVideoUrl }

--- a/hooks/use-web-rtc.tsx
+++ b/hooks/use-web-rtc.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect } from "react"
+import useNetworkChannel from "./use-network-channel"
 
 export interface UseWebRTCOptions {
   roomId: string
@@ -11,16 +12,38 @@ export default function useWebRTC({ roomId, isInitiator }: UseWebRTCOptions) {
   const localStreamRef = useRef<MediaStream | null>(null)
   const remoteStreamRef = useRef<MediaStream | null>(null)
   const peerRef = useRef<RTCPeerConnection | null>(null)
-  const channelRef = useRef<BroadcastChannel | null>(null)
 
   const [isConnected, setIsConnected] = useState(false)
   const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null)
   const [localStream, setLocalStream] = useState<MediaStream | null>(null)
 
-  useEffect(() => {
-    const channel = new BroadcastChannel(`webrtc-${roomId}`)
-    channelRef.current = channel
+  const { sendMessage } = useNetworkChannel(`webrtc-${roomId}`, async (msg) => {
+    if (!peerRef.current) return
+    switch (msg.type) {
+      case "offer":
+        if (!isInitiator) {
+          await peerRef.current.setRemoteDescription(new RTCSessionDescription(msg.offer))
+          const answer = await peerRef.current.createAnswer()
+          await peerRef.current.setLocalDescription(answer)
+          sendMessage({ type: "answer", answer })
+        }
+        break
+      case "answer":
+        if (isInitiator) {
+          await peerRef.current.setRemoteDescription(new RTCSessionDescription(msg.answer))
+        }
+        break
+      case "candidate":
+        try {
+          await peerRef.current.addIceCandidate(new RTCIceCandidate(msg.candidate))
+        } catch (err) {
+          console.error(err)
+        }
+        break
+    }
+  })
 
+  useEffect(() => {
     const peer = new RTCPeerConnection({
       iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
     })
@@ -30,10 +53,7 @@ export default function useWebRTC({ roomId, isInitiator }: UseWebRTCOptions) {
 
     peer.onicecandidate = (event) => {
       if (event.candidate) {
-        channel.postMessage({
-          type: "candidate",
-          candidate: event.candidate.toJSON(),
-        })
+        sendMessage({ type: "candidate", candidate: event.candidate.toJSON() })
       }
     }
 
@@ -46,34 +66,6 @@ export default function useWebRTC({ roomId, isInitiator }: UseWebRTCOptions) {
       setIsConnected(true)
     }
 
-    channel.onmessage = async (ev) => {
-      const msg = ev.data
-      if (!peerRef.current) return
-      switch (msg.type) {
-        case "offer":
-          if (!isInitiator) {
-            await peerRef.current.setRemoteDescription(new RTCSessionDescription(msg.offer))
-            const answer = await peerRef.current.createAnswer()
-            await peerRef.current.setLocalDescription(answer)
-            channel.postMessage({ type: "answer", answer })
-          }
-          break
-        case "answer":
-          if (isInitiator) {
-            await peerRef.current.setRemoteDescription(new RTCSessionDescription(msg.answer))
-          }
-          break
-        case "candidate":
-          try {
-            await peerRef.current.addIceCandidate(
-              new RTCIceCandidate(msg.candidate)
-            )
-          } catch (err) {
-            console.error(err)
-          }
-          break
-      }
-    }
 
     const start = async () => {
       try {
@@ -103,7 +95,7 @@ export default function useWebRTC({ roomId, isInitiator }: UseWebRTCOptions) {
         if (isInitiator) {
           const offer = await peer.createOffer()
           await peer.setLocalDescription(offer)
-          channel.postMessage({ type: "offer", offer })
+          sendMessage({ type: "offer", offer })
         }
       } catch (err) {
         console.error("Failed to get user media", err)
@@ -114,7 +106,6 @@ export default function useWebRTC({ roomId, isInitiator }: UseWebRTCOptions) {
 
     return () => {
       cancelled = true
-      channel.close()
       peer.close()
       localStreamRef.current?.getTracks().forEach((t) => t.stop())
       remoteStreamRef.current?.getTracks().forEach((t) => t.stop())


### PR DESCRIPTION
## Summary
- handle file messages even if video element isn't available yet
- use fetch polling for WebRTC and video-sync signaling
- add `/api/signaling` route for networked messages

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6856edecc9e0832fa72f7db30fee465c