### PR TITLE
Fix video sync handler bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The development server will start on `http://localhost:3000` by default.
 
 ## Known Issues / TODOs
 
-- The `use-video-sync` hook still contains leftover code (`channel.onmessage`) which references an undefined variable and likely breaks synchronization.
 - No authentication or persistence of rooms is implemented. All users join a default `main-room`.
 - Linting is not configured yet; running `npm run lint` prompts for setup.
 - The simple polling strategy in `use-network-channel` is inefficient and should be replaced with WebSockets for production use.

--- a/hooks/use-video-sync.tsx
+++ b/hooks/use-video-sync.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useRef, useState } from "react"
 import useNetworkChannel from "./use-network-channel"
 
 export interface VideoSyncMessage {
@@ -14,31 +14,26 @@ export default function useVideoSync(videoRef: React.RefObject<HTMLVideoElement>
   const { sendMessage } = useNetworkChannel("video-sync", (msg: VideoSyncMessage) => {
     if (msg.sender === idRef.current) return
 
-    channel.onmessage = (event: MessageEvent<VideoSyncMessage>) => {
-      const msg = event.data
-      if (msg.sender === idRef.current) return
+    const video = videoRef.current
 
-      const video = videoRef.current
-
-      switch (msg.type) {
-        case "file":
-          if (msg.dataUrl) setRemoteVideoUrl(msg.dataUrl)
-          break
-        case "play":
-          if (!video) return
-          if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
-          video.play().catch(() => {})
-          break
-        case "pause":
-          if (!video) return
-          if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
-          video.pause()
-          break
-        case "seek":
-          if (!video) return
-          if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
-          break
-      }
+    switch (msg.type) {
+      case "file":
+        if (msg.dataUrl) setRemoteVideoUrl(msg.dataUrl)
+        break
+      case "play":
+        if (!video) return
+        if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
+        video.play().catch(() => {})
+        break
+      case "pause":
+        if (!video) return
+        if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
+        video.pause()
+        break
+      case "seek":
+        if (!video) return
+        if (typeof msg.currentTime === "number") video.currentTime = msg.currentTime
+        break
     }
   })
 


### PR DESCRIPTION
## Summary
- clean up leftover `channel.onmessage` usage in video sync hook
- update README to remove resolved issue

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68579cbd9578832f9b8749465b126d39