### PR TITLE
Add advanced video playback controls

### DIFF
--- a/components/video-streamer.tsx
+++ b/components/video-streamer.tsx
@@ -5,7 +5,16 @@ import type React from "react"
 import { useState, useRef, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Play, Pause, Square, Volume2 } from "lucide-react"
+import {
+  Play,
+  Pause,
+  Square,
+  Volume2,
+  Fullscreen,
+  Minimize,
+  Subtitles,
+  Languages,
+} from "lucide-react"
 import FloatingVideoCall from "@/components/floating-video-call"
 import useVideoSync from "@/hooks/use-video-sync"
 
@@ -30,7 +39,13 @@ export default function VideoStreamer({
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
   const [videoUrl, setVideoUrl] = useState<string | null>(null)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [audioTracks, setAudioTracks] = useState<any[]>([])
+  const [selectedAudio, setSelectedAudio] = useState(0)
+  const [textTracks, setTextTracks] = useState<TextTrack[]>([])
+  const [subtitlesOn, setSubtitlesOn] = useState(false)
   const videoRef = useRef<HTMLVideoElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
   const { broadcast } = useVideoSync(videoRef)
 
   useEffect(() => {
@@ -46,6 +61,14 @@ export default function VideoStreamer({
       URL.revokeObjectURL(url)
     }
   }, [file])
+
+  useEffect(() => {
+    const handler = () => {
+      setIsFullscreen(!!document.fullscreenElement)
+    }
+    document.addEventListener("fullscreenchange", handler)
+    return () => document.removeEventListener("fullscreenchange", handler)
+  }, [])
 
   const togglePlay = () => {
     if (videoRef.current) {
@@ -69,6 +92,15 @@ export default function VideoStreamer({
   const handleLoadedMetadata = () => {
     if (videoRef.current) {
       setDuration(videoRef.current.duration)
+      const v = videoRef.current as any
+      if (v.audioTracks) {
+        const tracks = Array.from(v.audioTracks)
+        setAudioTracks(tracks)
+        tracks.forEach((t: any, i: number) => (t.enabled = i === selectedAudio))
+      }
+      const tt = Array.from(videoRef.current.textTracks)
+      setTextTracks(tt)
+      tt.forEach((t) => (t.mode = subtitlesOn ? "showing" : "disabled"))
     }
   }
 
@@ -81,6 +113,28 @@ export default function VideoStreamer({
     }
   }
 
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      containerRef.current?.requestFullscreen().catch(() => {})
+    } else {
+      document.exitFullscreen().catch(() => {})
+    }
+  }
+
+  const handleAudioSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const index = Number(e.target.value)
+    setSelectedAudio(index)
+    audioTracks.forEach((t, i) => {
+      if (t) (t as any).enabled = i === index
+    })
+  }
+
+  const toggleSubtitles = () => {
+    const enabled = !subtitlesOn
+    setSubtitlesOn(enabled)
+    textTracks.forEach((t) => (t.mode = enabled ? "showing" : "disabled"))
+  }
+
   const formatTime = (time: number) => {
     const minutes = Math.floor(time / 60)
     const seconds = Math.floor(time % 60)
@@ -91,7 +145,7 @@ export default function VideoStreamer({
     <div className="space-y-4">
       <Card>
         <CardContent className="p-0">
-          <div className="relative bg-black rounded-lg overflow-hidden">
+          <div ref={containerRef} className="relative bg-black rounded-lg overflow-hidden">
               {videoUrl ? (
                 <video
                   ref={videoRef}
@@ -126,6 +180,27 @@ export default function VideoStreamer({
                 </div>
 
                 <Volume2 className="w-4 h-4" />
+                {audioTracks.length > 1 && (
+                  <select
+                    value={selectedAudio}
+                    onChange={handleAudioSelect}
+                    className="bg-transparent text-white text-sm border border-white/30 rounded p-1"
+                  >
+                    {audioTracks.map((_, i) => (
+                      <option key={i} value={i} className="text-black">
+                        Audio {i + 1}
+                      </option>
+                    ))}
+                  </select>
+                )}
+                {textTracks.length > 0 && (
+                  <Button size="sm" variant="ghost" onClick={toggleSubtitles} className="text-white hover:bg-white/20">
+                    <Subtitles className="w-4 h-4" />
+                  </Button>
+                )}
+                <Button size="sm" variant="ghost" onClick={toggleFullscreen} className="text-white hover:bg-white/20">
+                  {isFullscreen ? <Minimize className="w-4 h-4" /> : <Fullscreen className="w-4 h-4" />}
+                </Button>
               </div>
             </div>
           </div>

--- a/components/video-viewer.tsx
+++ b/components/video-viewer.tsx
@@ -3,7 +3,18 @@
 import { useState, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Square, Wifi, WifiOff, Play, Pause, Volume2 } from "lucide-react"
+import {
+  Square,
+  Wifi,
+  WifiOff,
+  Play,
+  Pause,
+  Volume2,
+  Fullscreen,
+  Minimize,
+  Subtitles,
+  Languages,
+} from "lucide-react"
 import FloatingVideoCall from "@/components/floating-video-call"
 import useVideoSync from "@/hooks/use-video-sync"
 
@@ -26,7 +37,13 @@ export default function VideoViewer({
   const [isPlaying, setIsPlaying] = useState(false)
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [audioTracks, setAudioTracks] = useState<any[]>([])
+  const [selectedAudio, setSelectedAudio] = useState(0)
+  const [textTracks, setTextTracks] = useState<TextTrack[]>([])
+  const [subtitlesOn, setSubtitlesOn] = useState(false)
   const videoRef = useRef<HTMLVideoElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
   const { broadcast, remoteVideoUrl } = useVideoSync(videoRef)
 
   useEffect(() => {
@@ -34,6 +51,14 @@ export default function VideoViewer({
       setIsConnected(true)
     }
   }, [remoteVideoUrl])
+
+  useEffect(() => {
+    const handler = () => {
+      setIsFullscreen(!!document.fullscreenElement)
+    }
+    document.addEventListener("fullscreenchange", handler)
+    return () => document.removeEventListener("fullscreenchange", handler)
+  }, [])
 
   const togglePlay = () => {
     if (videoRef.current) {
@@ -57,6 +82,15 @@ export default function VideoViewer({
   const handleLoadedMetadata = () => {
     if (videoRef.current) {
       setDuration(videoRef.current.duration)
+      const v = videoRef.current as any
+      if (v.audioTracks) {
+        const tracks = Array.from(v.audioTracks)
+        setAudioTracks(tracks)
+        tracks.forEach((t: any, i: number) => (t.enabled = i === selectedAudio))
+      }
+      const tt = Array.from(videoRef.current.textTracks)
+      setTextTracks(tt)
+      tt.forEach((t) => (t.mode = subtitlesOn ? "showing" : "disabled"))
     }
   }
 
@@ -69,6 +103,28 @@ export default function VideoViewer({
     }
   }
 
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      containerRef.current?.requestFullscreen().catch(() => {})
+    } else {
+      document.exitFullscreen().catch(() => {})
+    }
+  }
+
+  const handleAudioSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const index = Number(e.target.value)
+    setSelectedAudio(index)
+    audioTracks.forEach((t, i) => {
+      if (t) (t as any).enabled = i === index
+    })
+  }
+
+  const toggleSubtitles = () => {
+    const enabled = !subtitlesOn
+    setSubtitlesOn(enabled)
+    textTracks.forEach((t) => (t.mode = enabled ? "showing" : "disabled"))
+  }
+
   const formatTime = (time: number) => {
     const minutes = Math.floor(time / 60)
     const seconds = Math.floor(time % 60)
@@ -79,7 +135,7 @@ export default function VideoViewer({
     <div className="space-y-4">
       <Card>
         <CardContent className="p-0">
-          <div className="relative bg-black rounded-lg overflow-hidden">
+          <div ref={containerRef} className="relative bg-black rounded-lg overflow-hidden">
             {!remoteVideoUrl ? (
               <div className="absolute inset-0 flex items-center justify-center">
                 <div className="text-center text-white">
@@ -117,11 +173,32 @@ export default function VideoViewer({
                       <span className="text-sm">{formatTime(duration)}</span>
                     </div>
 
-                    <Volume2 className="w-4 h-4" />
+                      <Volume2 className="w-4 h-4" />
+                      {audioTracks.length > 1 && (
+                        <select
+                          value={selectedAudio}
+                          onChange={handleAudioSelect}
+                          className="bg-transparent text-white text-sm border border-white/30 rounded p-1"
+                        >
+                          {audioTracks.map((_, i) => (
+                            <option key={i} value={i} className="text-black">
+                              Audio {i + 1}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                      {textTracks.length > 0 && (
+                        <Button size="sm" variant="ghost" onClick={toggleSubtitles} className="text-white hover:bg-white/20">
+                          <Subtitles className="w-4 h-4" />
+                        </Button>
+                      )}
+                      <Button size="sm" variant="ghost" onClick={toggleFullscreen} className="text-white hover:bg-white/20">
+                        {isFullscreen ? <Minimize className="w-4 h-4" /> : <Fullscreen className="w-4 h-4" />}
+                      </Button>
+                    </div>
                   </div>
-                </div>
-              </>
-            )}
+                </>
+              )}
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- add fullscreen, audio and subtitle controls to video player
- support track selection and toggling captions

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_68579dbf2b8c832fba1fb8d731b3afb9